### PR TITLE
Remove ENV.fetch calls

### DIFF
--- a/lib/zoo_stream.rb
+++ b/lib/zoo_stream.rb
@@ -27,7 +27,7 @@ module ZooStream
   end
 
   def self.source
-    @source || ENV.fetch("ZOO_STREAM_SOURCE")
+    @source || ENV["ZOO_STREAM_SOURCE"]
   end
 
   def self.source=(source)

--- a/lib/zoo_stream/kinesis_publisher.rb
+++ b/lib/zoo_stream/kinesis_publisher.rb
@@ -4,7 +4,7 @@ module ZooStream
   class KinesisPublisher
     attr_reader :stream_name, :client
 
-    def initialize(stream_name: ENV.fetch("ZOO_STREAM_KINESIS_STREAM_NAME"), client: Aws::Kinesis::Client.new)
+    def initialize(stream_name: ENV["ZOO_STREAM_KINESIS_STREAM_NAME"], client: Aws::Kinesis::Client.new)
       @stream_name = stream_name
       @client = client
     end


### PR DESCRIPTION
Unless you mean to raise exceptions on missing environment variables.

`ENV.fetch` with two arguments allows you to provide a default.  Maybe that's what you meant?
