### PR TITLE
update repo dev env and development gems

### DIFF
--- a/.github/workflows/run_tests_CI.yml
+++ b/.github/workflows/run_tests_CI.yml
@@ -1,0 +1,17 @@
+name: Zooni CI
+on:
+  pull_request:
+  push: { branches: master }
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: ruby
-rvm:
-  - 2.3.0
-before_install: gem install bundler -v 1.11.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ruby:2.7-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get -y upgrade && \
+    apt-get install --no-install-recommends -y \
+      # git is required for installing gems
+      git && \
+      apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# ensure we use a newer version of rubygems / bundler
+RUN gem update --system
+
+ADD ./Gemfile /app/
+ADD ./zoo_stream.gemspec /app/
+ADD ./ /app
+
+RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1`
+RUN bundle install

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+```
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/zooniverse/zoo_stream. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can either configure this gem using environment variables:
 Or programmatically (not recommended):
 
 ```ruby
-ZooStream.publisher = ZooStream::KinesisPublisher.new("zooniverse-production")
+ZooStream.publisher = ZooStream::KinesisPublisher.new(stream_name: "zooniverse-production")
 ZooStream.source = "my-application"
 ```
 
@@ -51,11 +51,22 @@ If you don't set a stream name, **this gem will silently ignore all `#publish` m
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rspec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+Use docker & compose to setup the dev env
+
+```shell
+docker-compose build
 ```
+
+Run a bash shell inside the new container
+
+```shell
+docker-compose run --service-ports --rm zoo_stream bash
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/zooniverse/zoo_stream. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  zoo_stream:
+    build:
+      context: .
+    volumes:
+      - ./:/app
+      - gem_cache:/usr/local/bundle
+
+volumes:
+  gem_cache:

--- a/zoo_stream.gemspec
+++ b/zoo_stream.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'aws-sdk'
 
-  spec.add_development_dependency "bundler", "~> 1.11"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency 'bundler', '~> 2.2'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
This is a maintenance PR, specifically to
- update the dev env of the repo (now using docker & compose) 
- upgrade the bundler, rake and rspec dev env gems
- update the readme
- remove travis CI and add GH Actions CI runner