### PR TITLE
v1.1.0 - Ruby 3 Compatibility - Update aws-sdk from v2 to aws-sdk-kinesis 

### DIFF
--- a/.github/workflows/run_tests_CI.yml
+++ b/.github/workflows/run_tests_CI.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.0
           bundler-cache: true
       - name: Run tests
         run: bundle exec rspec

--- a/.github/workflows/run_tests_CI.yml
+++ b/.github/workflows/run_tests_CI.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: 3.0.1
           bundler-cache: true
       - name: Run tests
         run: bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.1.0
+
+* Ruby 3 compatibility
+    - Update aws-sdk to v3 and only install service specific aws-sdk-kinesis
+
 # 1.0.1
 
 * Made compatible down to Ruby 2.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7-slim
+FROM ruby:3.1-slim
 
 WORKDIR /app
 

--- a/lib/zoo_stream/kinesis_publisher.rb
+++ b/lib/zoo_stream/kinesis_publisher.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-kinesis'
 
 module ZooStream
   class KinesisPublisher
@@ -11,7 +11,7 @@ module ZooStream
 
     def publish(event, shard_by: nil)
       raise ArgumentError, "Must specify shard_by" unless shard_by
-      
+
       client.put_record(
         stream_name: stream_name,
         partition_key: shard_by,

--- a/lib/zoo_stream/version.rb
+++ b/lib/zoo_stream/version.rb
@@ -1,3 +1,3 @@
 module ZooStream
-  VERSION = "1.0.1"
+  VERSION = "1.1.0"
 end

--- a/zoo_stream.gemspec
+++ b/zoo_stream.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'aws-sdk'
+  spec.add_dependency 'aws-sdk-kinesis'
 
   spec.add_development_dependency 'bundler', '~> 2.2'
   spec.add_development_dependency 'rake'

--- a/zoo_stream.gemspec
+++ b/zoo_stream.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'aws-sdk-kinesis'
+  spec.add_dependency 'aws-sdk-kinesis', '~> 1'
 
   spec.add_development_dependency 'bundler', '~> 2.2'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
update to be compatible with ruby 3 by replacing aws-sdk to more specific aws-sdk-kinesis

See: https://github.com/aws/aws-sdk-ruby/blob/version-3/V3_UPGRADING_GUIDE.md
